### PR TITLE
bugfix of "String::split"

### DIFF
--- a/include/phpx.h
+++ b/include/phpx.h
@@ -515,7 +515,7 @@ public:
     {
         if (free_memory)
         {
-            zend_string_free(value);
+            zend_string_release(value);
         }
     }
     inline long toInt()

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -603,7 +603,7 @@ public:
 				value->len, 1, flags, (char *) charset.c_str());
 	}
 
-	Variant split(String &delim, int limit = -1);
+	Variant split(String &delim, long = ZEND_LONG_MAX);
     String substr(long _offset, long _length = -1);
     void stripTags(String &allow, bool allow_tag_spaces = false);
     String addSlashes();

--- a/src/string.cc
+++ b/src/string.cc
@@ -84,9 +84,9 @@ String String::substr(long _offset, long _length)
     return String(value->val + _offset, _length);
 }
 
-Variant String::split(String &delim, int limit)
+Variant String::split(String &delim, long limit)
 {
-	Variant retval;
+	Array retval;
 	php_explode(delim.ptr(), value, retval.ptr(), limit);
 	retval.addRef();
 	return retval;


### PR DESCRIPTION
commit c3993f5：
1，需要传入分配好的array，否则会coredump。
2，limit=-1无法表示不限制，使用ZEND_LONG_MAX。

commit 62de50c：
1，String析构函数有问题，修复。