### PR TITLE
bugfix: ArrayIterator out of bound

### DIFF
--- a/include/phpx.h
+++ b/include/phpx.h
@@ -651,15 +651,14 @@ public:
     }
     void operator ++(int i)
     {
-        while (1)
+        while (++_ptr != pe)
         {
-            _ptr++;
             _val = &_ptr->val;
             if (_val && Z_TYPE_P(_val) == IS_INDIRECT)
             {
                 _val = Z_INDIRECT_P(_val);
             }
-            if (UNEXPECTED(Z_TYPE_P(_val) == IS_UNDEF) && pe != _ptr)
+            if (UNEXPECTED(Z_TYPE_P(_val) == IS_UNDEF))
             {
                 continue;
             }


### PR DESCRIPTION
原先实现会导致越界访问内存，修复它。

业务场景：

```
		for (auto iter = uri_items.begin(); iter != uri_items.end(); iter++) {
			fmt_one = iter.value().toCString();
			// 1，纯数字替换为{num}
			fmt_one = std::regex_replace(fmt_one, first, "{num}");
			// 2，前缀+数字替换为前缀+{num}
			fmt_one = std::regex_replace(fmt_one, second, "$1{num}");
			fmt_items.set(iter.key().toInt(), fmt_one);
		}
```