### PR TITLE
extension支持声明ini配置

### DIFF
--- a/include/phpx.h
+++ b/include/phpx.h
@@ -651,15 +651,14 @@ public:
     }
     void operator ++(int i)
     {
-        while (1)
+        while (++_ptr != pe)
         {
-            _ptr++;
             _val = &_ptr->val;
             if (_val && Z_TYPE_P(_val) == IS_INDIRECT)
             {
                 _val = Z_INDIRECT_P(_val);
             }
-            if (UNEXPECTED(Z_TYPE_P(_val) == IS_UNDEF) && pe != _ptr)
+            if (UNEXPECTED(Z_TYPE_P(_val) == IS_UNDEF))
             {
                 continue;
             }

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -515,7 +515,7 @@ public:
     {
         if (free_memory)
         {
-            zend_string_free(value);
+            zend_string_release(value);
         }
     }
     inline long toInt()

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -1642,6 +1642,9 @@ extern int extension_after_request(int type, int module_number);
 
 class Extension
 {
+    friend int extension_startup(int type, int module_number);
+    friend int extension_shutdown(int type, int module_number);
+
 protected:
     zend_module_entry module =
     {
@@ -1658,6 +1661,16 @@ protected:
     NULL, //version
     STANDARD_MODULE_PROPERTIES,
     };
+
+    // INI
+    struct IniEntry {
+        std::string name;
+        std::string default_value;
+        int modifiable;
+    };
+
+    void registerIniEntries(int module_number);
+    void unregisterIniEntries(int module_number);
 
 public:
 
@@ -1700,6 +1713,16 @@ public:
         this->body = body;
     }
 
+    // modifiable can be one of these:PHP_INI_SYSTEM/PHP_INI_PERDIR/PHP_INI_USER/PHP_INI_ALL
+    void addIniEntry(const char* name, const char* default_value = "", int modifiable = PHP_INI_ALL)
+    {
+        IniEntry entry;
+        entry.name = name;
+        entry.default_value = default_value;
+        entry.modifiable = modifiable;
+        ini_entries.push_back(entry);
+    }
+
     string name;
     string version;
     bool started = false;
@@ -1717,6 +1740,8 @@ protected:
     int function_array_size = 0;
     int deps_count = 0;
     int deps_array_size = 0;
+
+    std::vector<IniEntry> ini_entries;
 };
 
 extern unordered_map<string, Extension*> _name_to_extension;

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -603,7 +603,7 @@ public:
 				value->len, 1, flags, (char *) charset.c_str());
 	}
 
-	Variant split(String &delim, int limit = -1);
+	Variant split(String &delim, long = ZEND_LONG_MAX);
     String substr(long _offset, long _length = -1);
     void stripTags(String &allow, bool allow_tag_spaces = false);
     String addSlashes();

--- a/src/base.cc
+++ b/src/base.cc
@@ -67,6 +67,7 @@ int extension_startup(int type, int module_number)
         {
             Extension *extension = _name_to_extension[module->name];
             extension->started = true;
+            extension->registerIniEntries(module_number);
             if (extension->onStart)
             {
                 extension->onStart();
@@ -126,6 +127,7 @@ int extension_shutdown(int type, int module_number)
     {
         extension->onShutdown();
     }
+    extension->unregisterIniEntries(module_number);
     _name_to_extension.erase(extension->name);
     _module_number_to_extension.erase(module_number);
     delete extension;

--- a/src/extension.cc
+++ b/src/extension.cc
@@ -194,4 +194,39 @@ bool Extension::registerFunction(const char *name, function_t func, ArgInfo *inf
     return true;
 }
 
+void Extension::registerIniEntries(int module_number) {
+    if (!ini_entries.size()) {
+        return;
+    }
+
+    zend_ini_entry_def* entry_defs = new zend_ini_entry_def[ini_entries.size() + 1];
+
+    for (auto i = 0; i < ini_entries.size(); ++i) {
+        IniEntry& entry = ini_entries[i];
+        zend_ini_entry_def def = {
+                entry.name.c_str(), // name
+                NULL,   // on_modify
+                NULL,   // mh_arg1
+                NULL,   // mh_arg2
+                NULL,   // mh_arg3
+                entry.default_value.c_str(), // value
+                NULL,   // displayer
+                entry.modifiable, // modifiable
+                (uint)entry.name.size(), // name_length
+                (uint)entry.default_value.size(), // value_length
+        };
+        entry_defs[i] = def;
+    }
+    memset(entry_defs + ini_entries.size(), 0, sizeof(*entry_defs));
+
+    zend_register_ini_entries(entry_defs, module_number);
+    delete []entry_defs;
+}
+
+void Extension::unregisterIniEntries(int module_number) {
+    if (ini_entries.size()) {
+        zend_unregister_ini_entries(module_number);
+    }
+}
+
 }

--- a/src/string.cc
+++ b/src/string.cc
@@ -84,9 +84,9 @@ String String::substr(long _offset, long _length)
     return String(value->val + _offset, _length);
 }
 
-Variant String::split(String &delim, int limit)
+Variant String::split(String &delim, long limit)
 {
-	Variant retval;
+	Array retval;
 	php_explode(delim.ptr(), value, retval.ptr(), limit);
 	retval.addRef();
 	return retval;


### PR DESCRIPTION
新增接口：
```
    // modifiable can be one of these:PHP_INI_SYSTEM/PHP_INI_PERDIR/PHP_INI_USER/PHP_INI_ALL
    void addIniEntry(const char* name, const char* default_value = "", int modifiable = PHP_INI_ALL)
    {
        IniEntry entry;
        entry.name = name;
        entry.default_value = default_value;
        entry.modifiable = modifiable;
        ini_entries.push_back(entry);
    }
```

用法：
```
// 导出扩展
PHPX_EXTENSION()
{
    // 创建PHP扩展
    Extension *extension = new Extension("catx", "0.0.1");
    // 注册ini
    extension->addIniEntry("catx.abc", "hi");
```
