### PR TITLE
完善variant,array的拷贝语义

### DIFF
--- a/examples/gtk/gtk.cc
+++ b/examples/gtk/gtk.cc
@@ -34,7 +34,6 @@ static vector<Variant *> callbacks;
 void PHP_Gtk_callback(GtkApplication* app, gpointer user_data)
 {
     Variant v = *(Variant *) user_data;
-    v.addRef();
     call(v);
 }
 

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -343,13 +343,9 @@ public:
         }
         return Z_TYPE_P(ptr()) == IS_TRUE;
     }
-    Variant dup()
+    Variant* dup()
     {
-        zval dupv;
-        memcpy(&dupv, ptr(), sizeof(dupv));
-        zval_copy_ctor_func(&dupv);
-        zval_delref_p(&dupv);
-        return Variant(&dupv);
+        return new Variant(this);
     }
     inline size_t length()
     {

--- a/src/array.cc
+++ b/src/array.cc
@@ -145,7 +145,6 @@ Array Array::slice(long offset, long length, bool preserve_keys)
         ZEND_HASH_FOREACH_END();
     }
     Array retval(&return_value);
-    retval.addRef();
     return retval;
 }
 

--- a/src/base.cc
+++ b/src/base.cc
@@ -203,7 +203,6 @@ Variant _call(zval *object, zval *func, Args &args)
     }
     if (call_user_function(EG(function_table), object, func, retval.ptr(), args.count(), params) == SUCCESS)
     {
-        retval.addRef();
         return retval;
     }
     else
@@ -217,7 +216,6 @@ Variant _call(zval *object, zval *func)
     Variant retval = false;
     if (call_user_function(EG(function_table), object, func, retval.ptr(), 0, NULL) == 0)
     {
-        retval.addRef();
         return retval;
     }
     else

--- a/src/extension.cc
+++ b/src/extension.cc
@@ -136,7 +136,6 @@ bool Extension::registerConstant(const char *name, Variant &v)
     this->checkStartupStatus(AFTER_START, __func__);
     zend_constant *c = new zend_constant;
     ZVAL_COPY(&c->value, v.ptr());
-    v.addRef();
     c->flags = CONST_CS;
     c->name = zend_string_init(name, strlen(name), c->flags);
     c->module_number = module.module_number;

--- a/src/string.cc
+++ b/src/string.cc
@@ -88,7 +88,6 @@ Variant String::split(String &delim, long limit)
 {
 	Array retval;
 	php_explode(delim.ptr(), value, retval.ptr(), limit);
-	retval.addRef();
 	return retval;
 }
 

--- a/src/variant.cc
+++ b/src/variant.cc
@@ -69,7 +69,6 @@ Variant Variant::serialize()
     PHP_VAR_SERIALIZE_DESTROY(var_hash);
     Variant retval(serialized_data.s->val, serialized_data.s->len);
     smart_str_free(&serialized_data);
-    retval.addRef();
     return retval;
 }
 
@@ -83,7 +82,6 @@ Variant Variant::unserialize()
     size_t length = Z_STRLEN_P(ptr());
     if (php_var_unserialize(retval.ptr(), (const uchar **) &data, (const uchar *) data + length, &var_hash))
     {
-        retval.addRef();
         return retval;
     }
     else
@@ -126,7 +124,6 @@ Variant Variant::jsonDecode(zend_long options, zend_long depth)
     options |= PHP_JSON_OBJECT_AS_ARRAY;
     Variant retval;
     php_json_decode_ex(retval.ptr(), Z_STRVAL_P(ptr()), Z_STRLEN_P(ptr()), options, depth);
-    retval.addRef();
     return retval;
 }
 


### PR DESCRIPTION
对Variant和Array改动较多，这是一个可用的版本（在我的业务里可以正常工作），需要一起看看。

1，主要是增加了Variant的拷贝构造，完善了原先的拷贝赋值，删除了在Variant构造函数之外的addRef调用。
2，现在的Variant拷贝应该是对zval的生命延续，而产生Variant副本则应该通过dup函数创建。
3，Array是支持数组操作的Variant，但是其拷贝构造函数额外的考虑了Array(retval)的用法，也就是Variant如果是zend函数返回值的话，那么采用ref_val直接引用的方式保存。

上述改动的目的，主要是支持Variant之间互相拷贝构造，互相赋值，以及Array和Variant之间互相拷贝，互相赋值。

后面考虑对String，Object也做一些完善，确保用户使用起来没有太多疑虑。