### PR TITLE
对参数个数进行校验

### DIFF
--- a/include/phpx.h
+++ b/include/phpx.h
@@ -1471,6 +1471,8 @@ extern map<const char *, function_t, strCmp> function_map;
 
 extern void _exec_function(zend_execute_data *data, zval *return_value);
 extern void _exec_method(zend_execute_data *data, zval *return_value);
+extern ZEND_RESULT_CODE _check_args_num(zend_execute_data *data, int arg_count);
+
 
 String number_format(double num, int decimals = 0, char dec_point = '.', char thousands_sep = ',');
 Variant http_build_query(const Variant &data, const char* prefix = nullptr, const char* arg_sep = nullptr,

--- a/src/base.cc
+++ b/src/base.cc
@@ -167,6 +167,11 @@ void _exec_function(zend_execute_data *data, zval *return_value)
     zval *param_ptr = ZEND_CALL_ARG(EG(current_execute_data), 1);
     int arg_count = ZEND_CALL_NUM_ARGS(EG(current_execute_data));
 
+    if(_check_args_num(data, arg_count) == FAILURE)
+    {
+        return;
+    }
+
     while (arg_count-- > 0)
     {
         args.append(param_ptr);
@@ -186,6 +191,11 @@ void _exec_method(zend_execute_data *data, zval *return_value)
     zval *param_ptr = ZEND_CALL_ARG(EG(current_execute_data), 1);
     int arg_count = ZEND_CALL_NUM_ARGS(EG(current_execute_data));
 
+    if(_check_args_num(data, arg_count) == FAILURE)
+    {
+        return;
+    }
+
     while (arg_count-- > 0)
     {
         args.append(param_ptr);
@@ -194,6 +204,26 @@ void _exec_method(zend_execute_data *data, zval *return_value)
     Variant _retval(return_value, true);
     func(_this, args, _retval);
 }
+
+ZEND_RESULT_CODE _check_args_num(zend_execute_data *data, int num_args)
+{
+    uint32_t min_num_args = data->func->common.required_num_args;
+    uint32_t max_num_args = data->func->common.num_args;
+
+    if (num_args < min_num_args || (num_args > max_num_args && max_num_args > 0)) 
+    {
+        #if PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION == 0
+        zend_wrong_paramers_count_error(num_args, min_num_args, max_num_args);
+        #else
+        zend_wrong_parameters_count_error(num_args, min_num_args, max_num_args);
+        #endif
+
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
 
 Variant _call(zval *object, zval *func, Args &args)
 {


### PR DESCRIPTION
PHP-X不会对参数个数进行校验并报错。

在默认情况下，调用`zend_parse_parameters()`或`ZEND_PARSE_PARAMETERS_START()`和`ZEND_PARSE_PARAMETERS_END()`时，若参数个数不正确是会给出一个warning错误并且停止调用。

所以我觉得非常有必要添加对参数个数校验的支持，并且此次修改是向下兼容的（即：若没有为方法定义ArgInfo则不会抛出Warning）

我已经对代码进行过测试，测试用例在这：https://github.com/kong36088/PHP-X-demo/tree/master/args